### PR TITLE
Cut blocks to prevent out of memory in POA

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "deps/libbf"]
 	path = deps/libbf
 	url = https://github.com/mavam/libbf.git
+[submodule "deps/sautocorr"]
+	path = deps/sautocorr
+	url = https://github.com/ekg/sautocorr.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,15 @@ ExternalProject_Add(xoshiro
 ExternalProject_Get_property(xoshiro SOURCE_DIR)
 set(xoshiro_INCLUDE "${SOURCE_DIR}")
 
+ExternalProject_Add(sautocorr
+  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/sautocorr"
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(sautocorr SOURCE_DIR)
+set(sautocorr_INCLUDE "${SOURCE_DIR}")
+
 add_subdirectory(deps/spoa EXCLUDE_FROM_ALL)
 set(spoa_INCLUDE "${CMAKE_SOURCE_DIR}/deps/spoa/include")
 
@@ -216,7 +225,8 @@ add_library(smoothxg_objs OBJECT
   src/prep.cpp
   src/blocks.cpp
   src/breaks.cpp
-  src/smooth.cpp)
+  src/smooth.cpp
+  ${sautocorr_INCLUDE}/sautocorr.cpp)
 
 add_dependencies(smoothxg_objs handlegraph)
 add_dependencies(smoothxg_objs sdsl-lite)
@@ -232,6 +242,7 @@ add_dependencies(smoothxg_objs paryfor)
 add_dependencies(smoothxg_objs libbf)
 add_dependencies(smoothxg_objs dirtyzipf)
 add_dependencies(smoothxg_objs xoshiro)
+add_dependencies(smoothxg_objs sautocorr)
 
 set_target_properties(smoothxg_objs PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
@@ -278,7 +289,8 @@ set(smoothxg_INCLUDES
   "${libbf_INCLUDE}"
   "${random_dist_INCLUDE}"
   "${dirtyzipf_INCLUDE}"
-  "${xoshiro_INCLUDE}")
+  "${xoshiro_INCLUDE}"
+  "${sautocorr_INCLUDE}")
 
 set(smoothxg_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ add_library(smoothxg_objs OBJECT
   src/chain.cpp
   src/prep.cpp
   src/blocks.cpp
+  src/breaks.cpp
   src/smooth.cpp)
 
 add_dependencies(smoothxg_objs handlegraph)

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -57,7 +57,7 @@ smoothable_blocks(
             std::vector<path_range_t> path_ranges;
             for (auto& step : traversals) {
                 if (path_ranges.empty()) {
-                    path_ranges.push_back({step, step});
+                    path_ranges.push_back({step, step, 0});
                 } else {
                     auto& path_range = path_ranges.back();
                     auto& last = path_range.end;
@@ -66,7 +66,7 @@ smoothable_blocks(
                             - (graph.get_position_of_step(last) + graph.get_length(graph.get_handle_of_step(last)))
                             > max_path_jump)) {
                         // make a new range
-                        path_ranges.push_back({step, step});
+                        path_ranges.push_back({step, step, 0});
                     } else {
                         // extend the range
                         last = step;
@@ -137,7 +137,7 @@ smoothable_blocks(
                 block.max_path_length = std::max(included_path_length,
                                                  block.max_path_length);
             }
-            std::cerr << "max_path_length " << block.max_path_length << std::endl;
+            //std::cerr << "max_path_length " << block.max_path_length << std::endl;
 
             // order the path ranges from longest to shortest
             ips4o::parallel::sort(

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -9,9 +9,11 @@ smoothable_blocks(
     const uint64_t& max_path_jump,
     const uint64_t& min_subpath,
     const uint64_t& max_edge_jump) {
-    // iterate over the handles in their vectorized order
+    // iterate over the handles in their vectorized order, collecting blocks that we can potentially smooth
     std::vector<block_t> blocks;
     std::vector<std::vector<bool>> seen_steps;
+    // cast to vectorizable graph for determining the sort position of nodes
+    const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
     std::cerr << "[smoothxg::smoothable_blocks] computing blocks" << std::endl;
     graph.for_each_path_handle(
         [&](const path_handle_t& path) {
@@ -50,7 +52,8 @@ smoothable_blocks(
             // determine the path ranges in the block
             // break them when we pass some threshold for how much block-external sequence to include
             // (this parameter is meant to allow us to reduce dispersed collapses in the graph)
-            // TODO optionally break when we have a significant change in coverage relative to the average in the region
+            // break them when they jump more than max_edge_jump in our graph sort order
+            // TODO explore breaking when we have a significant change in coverage relative to the average in the region
             std::vector<path_range_t> path_ranges;
             for (auto& step : traversals) {
                 if (path_ranges.empty()) {
@@ -70,7 +73,7 @@ smoothable_blocks(
                     }
                 }
             }
-            // break the blocks on ranges of seen steps
+            // break the path ranges on seen steps
             for (auto& path_range : path_ranges) {
                 uint64_t included_path_length = 0;
                 // update the path range end to point to the one-past element
@@ -122,6 +125,7 @@ smoothable_blocks(
                           << "-"
                           << graph.get_id(graph.get_handle_of_step(graph.get_previous_step(path_range.end))) << std::endl;
                 */
+                // here we need to break when we see significant nonlinearities
                 for (step_handle_t curr_step = path_range.begin;
                      curr_step != path_range.end;
                      curr_step = graph.get_next_step(curr_step)) {
@@ -133,7 +137,7 @@ smoothable_blocks(
                 block.max_path_length = std::max(included_path_length,
                                                  block.max_path_length);
             }
-            //std::cerr << "max_path_length " << block.max_path_length << std::endl;
+            std::cerr << "max_path_length " << block.max_path_length << std::endl;
 
             // order the path ranges from longest to shortest
             ips4o::parallel::sort(
@@ -154,7 +158,6 @@ smoothable_blocks(
             */                    
         };
     //uint64_t id = 0;
-    const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
     graph.for_each_handle(
         [&](const handle_t& handle) {
             if (graph.get_id(handle) % 100 == 0) {

--- a/src/breaks.cpp
+++ b/src/breaks.cpp
@@ -1,0 +1,126 @@
+#include "breaks.hpp"
+
+namespace smoothxg {
+
+using namespace handlegraph;
+
+// break the path ranges at likely VNTR boundaries
+// and break the path ranges to be shorter than our "max" sequence size input to spoa
+void break_blocks(const xg::XG& graph,
+                  std::vector<block_t>& blocks,
+                  const uint64_t& max_poa_length,
+                  const uint64_t& min_copy_length,
+                  const uint64_t& max_copy_length,
+                  const uint64_t& min_autocorr_z,
+                  const uint64_t& autocorr_stride) {
+
+    const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
+
+    std::cerr << "[smoothxg::break_blocks] cutting blocks that contain sequences above max-poa-length" << std::endl;
+
+    uint64_t n_cut_blocks = 0;
+    uint64_t n_repeat_blocks = 0;
+    for (auto& block : blocks) {
+        // check if we have sequences that are too long
+        bool to_break = false;
+        for (auto& path_range : block.path_ranges) {
+            if (path_range.length > max_poa_length) {
+                to_break = true;
+                break;
+            }
+        }
+        if (!to_break) continue; // skip if we're spoa-able
+        // otherwise let's see if we've got repeats that we can use to chop things up
+        // find if there is a repeat
+        std::vector<sautocorr::repeat_t> repeats;
+        for (auto& path_range : block.path_ranges) {
+            // steps in id space
+            std::string seq;
+            std::string name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+            for (step_handle_t step = path_range.begin;
+                 step != path_range.end;
+                 step = graph.get_next_step(step)) {
+                seq.append(graph.get_sequence(graph.get_handle_of_step(step)));
+            }
+            if (seq.length() < 2*min_copy_length) continue;
+            //std::cerr << "on " << name << "\t" << seq.length() << std::endl;
+            std::vector<uint8_t> vec(seq.begin(), seq.end());
+            sautocorr::repeat_t result = sautocorr::repeat(vec,
+                                                           min_copy_length,
+                                                           max_copy_length,
+                                                           min_copy_length,
+                                                           min_autocorr_z,
+                                                           autocorr_stride);
+            repeats.push_back(result);
+            /*
+            std::cerr << name
+                      << "\t" << seq.length()
+                      << "\t" << result.length
+                      << "\t" << result.z_score << std::endl;
+            */
+        }
+        // if there is, set the cut length to some fraction of it
+        std::vector<double> lengths;
+        for (auto& repeat : repeats) {
+            if (repeat.length > 0) {
+                lengths.push_back(repeat.length);
+            }
+        }
+        uint64_t cut_length;
+        bool found_repeat = !lengths.empty();
+        if (found_repeat) {
+            double repeat_length = sautocorr::vec_mean(lengths.begin(), lengths.end());
+            cut_length = std::round(repeat_length / 2.0);
+            ++n_repeat_blocks;
+            //std::cerr << "found repeat of " << repeat_length << " cutting to " << cut_length << std::endl;
+        } else {
+            // if not, chop blindly
+            cut_length = max_poa_length;
+        }
+        ++n_cut_blocks;
+        std::vector<path_range_t> chopped_ranges;
+        for (auto& path_range : block.path_ranges) {
+
+            if (!found_repeat && path_range.length < cut_length) {
+                chopped_ranges.push_back(path_range);
+                continue;
+            }
+            // now find outlier clusters based on stdev and mean
+            // extract a minimum viable repeat length
+            // scan across the step vector, looking for where the repeat region begins and ends
+            // cut at the repeat boundaries
+
+            // Q: should we determine the repeat length for each sequence or all?
+            // each is simple, but maybe expensive
+            // all could provide higher precision, but it's muddier
+
+            // if this doesn't work, we're going to blindly cut anyway
+            uint64_t last_cut = 0;
+            step_handle_t last_end = path_range.begin;
+            //path_range_t* new_range = nullptr;
+            uint64_t pos = 0;
+            step_handle_t step;
+            for (step = path_range.begin;
+                 step != path_range.end;
+                 step = graph.get_next_step(step)) {
+                //handle_t h = graph.get_handle_of_step(step);
+                //uint64_t id = graph.get_id(h);
+                //int64_t node_pos = vec_graph.node_vector_offset(id);
+                pos += graph.get_length(graph.get_handle_of_step(step));
+                if (pos - last_cut > cut_length) {
+                    step_handle_t next = graph.get_next_step(step);
+                    chopped_ranges.push_back({last_end, next, pos - last_cut});
+                    last_end = next;
+                    last_cut = pos;
+                }
+            }
+            if (step != last_end) {
+                chopped_ranges.push_back({last_end, step, pos - last_cut});
+            }
+        }
+        block.path_ranges = chopped_ranges;
+    }
+    std::cerr << "[smoothxg::break_blocks] cut " << n_cut_blocks << " blocks of which " << n_repeat_blocks << " had repeats" << std::endl;
+}
+
+}

--- a/src/breaks.hpp
+++ b/src/breaks.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <iostream>
+#include <chrono>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <vector>
+#include <numeric>
+#include <cmath>
+#include "blocks.hpp"
+#include "sautocorr.hpp"
+#include "xg.hpp"
+
+namespace smoothxg {
+
+using namespace handlegraph;
+
+// break the path ranges at likely VNTR boundaries
+// and break the path ranges to be shorter than our "max" sequence size input to spoa
+void break_blocks(const xg::XG& graph,
+                  std::vector<block_t>& blocks,
+                  const uint64_t& max_poa_length,
+                  const uint64_t& min_copy_length,
+                  const uint64_t& max_copy_length,
+                  const uint64_t& min_autocorr_z,
+                  const uint64_t& autocorr_stride);
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,17 +32,17 @@ int main(int argc, char** argv) {
     args::Flag add_consensus(parser, "bool", "include consensus sequence in graph", {'a', "add-consensus"});
     args::ValueFlag<uint64_t> _max_block_weight(parser, "N", "maximum seed sequence in block [default: 10000]", {'w', "max-block-weight"});
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
-    args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0]", {'k', "min-subpath"});
-    args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 100]", {'e', "max-edge-jump"});
+    args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 16]", {'k', "min-subpath"});
+    args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 1000]", {'e', "max-edge-jump"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
     args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'m', "max-copy-length"});
     args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "max-poa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
-    args::ValueFlag<int> _poa_m(parser, "N", "poa score for matching bases [default: 1]", {'M', "poa-match"});
+    args::ValueFlag<int> _poa_m(parser, "N", "poa score for matching bases [default: 2]", {'M', "poa-match"});
     args::ValueFlag<int> _poa_n(parser, "N", "poa score for mismatching bases [default: -4]", {'N', "poa-mismatch"});
-    args::ValueFlag<int> _poa_g(parser, "N", "poa gap opening penalty (must be negative) [default: -6]", {'G', "poa-gap-open"});
+    args::ValueFlag<int> _poa_g(parser, "N", "poa gap opening penalty (must be negative) [default: -4]", {'G', "poa-gap-open"});
     args::ValueFlag<int> _poa_e(parser, "N", "poa gap extension penalty (must be negative) [default: -2]", {'E', "poa-gap-extend"});
-    args::ValueFlag<int> _poa_q(parser, "N", "poa gap opening penalty of the second affine function (must be negative) [default: -8]", {'Q', "poa-2nd-gap-open"});
+    args::ValueFlag<int> _poa_q(parser, "N", "poa gap opening penalty of the second affine function (must be negative) [default: -24]", {'Q', "poa-2nd-gap-open"});
     args::ValueFlag<int> _poa_c(parser, "N", "poa gap extension penalty of the second affine function (must be negative) [default: -1]", {'C', "poa-2nd-gap-extend"});
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 10]", {'X', "chop-to"});
     args::ValueFlag<float> _prep_sgd_min_term_updates(parser, "N", "path-guided SGD sort quality parameter (N * sum_path_length updates per iteration) for graph prep [default: 1]", {'U', "path-sgd-term-updates"});
@@ -96,17 +96,17 @@ int main(int argc, char** argv) {
 
     uint64_t max_block_weight = _max_block_weight ? args::get(_max_block_weight) : 10000;
     uint64_t max_block_jump = _max_block_jump ? args::get(_max_block_jump) : 5000;
-    uint64_t min_subpath = _min_subpath ? args::get(_min_subpath) : 0;
-    uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 100;
+    uint64_t min_subpath = _min_subpath ? args::get(_min_subpath) : 16;
+    uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 1000;
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
 
-    std::int8_t poa_m = 1;
+    std::int8_t poa_m = 2;
     std::int8_t poa_n = -4;
-    std::int8_t poa_g = -6;
-    std::int8_t poa_e = -1;
-    std::int8_t poa_q = -6;
+    std::int8_t poa_g = -4;
+    std::int8_t poa_e = -2;
+    std::int8_t poa_q = -24;
     std::int8_t poa_c = -1;
 
     if (_poa_m) poa_m = args::get(_poa_m);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,14 +36,14 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 100]", {'e', "max-edge-jump"});
     args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
     args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'m', "max-copy-length"});
-    args::ValueFlag<uint64_t> _max_spoa_length(parser, "N", "maximum sequence length to put into spoa [default: 10000]", {'l', "max-spoa-length"});
+    args::ValueFlag<uint64_t> _max_poa_length(parser, "N", "maximum sequence length to put into poa [default: 10000]", {'l', "max-poa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
-    args::ValueFlag<int> _poa_m(parser, "N", "spoa score for matching bases [default: 1]", {'M', "poa-match"});
-    args::ValueFlag<int> _poa_n(parser, "N", "spoa score for mismatching bases [default: -4]", {'N', "poa-mismatch"});
-    args::ValueFlag<int> _poa_g(parser, "N", "spoa gap opening penalty (must be negative) [default: -6]", {'G', "poa-gap-open"});
-    args::ValueFlag<int> _poa_e(parser, "N", "spoa gap extension penalty (must be negative) [default: -2]", {'E', "poa-gap-extend"});
-    args::ValueFlag<int> _poa_q(parser, "N", "spoa gap opening penalty of the second affine function (must be negative) [default: -8]", {'Q', "poa-2nd-gap-open"});
-    args::ValueFlag<int> _poa_c(parser, "N", "spoa gap extension penalty of the second affine function (must be negative) [default: -1]", {'C', "poa-2nd-gap-extend"});
+    args::ValueFlag<int> _poa_m(parser, "N", "poa score for matching bases [default: 1]", {'M', "poa-match"});
+    args::ValueFlag<int> _poa_n(parser, "N", "poa score for mismatching bases [default: -4]", {'N', "poa-mismatch"});
+    args::ValueFlag<int> _poa_g(parser, "N", "poa gap opening penalty (must be negative) [default: -6]", {'G', "poa-gap-open"});
+    args::ValueFlag<int> _poa_e(parser, "N", "poa gap extension penalty (must be negative) [default: -2]", {'E', "poa-gap-extend"});
+    args::ValueFlag<int> _poa_q(parser, "N", "poa gap opening penalty of the second affine function (must be negative) [default: -8]", {'Q', "poa-2nd-gap-open"});
+    args::ValueFlag<int> _poa_c(parser, "N", "poa gap extension penalty of the second affine function (must be negative) [default: -1]", {'C', "poa-2nd-gap-extend"});
     args::ValueFlag<int> _prep_node_chop(parser, "N", "during prep, chop nodes to this length [default: 10]", {'X', "chop-to"});
     args::ValueFlag<float> _prep_sgd_min_term_updates(parser, "N", "path-guided SGD sort quality parameter (N * sum_path_length updates per iteration) for graph prep [default: 1]", {'U', "path-sgd-term-updates"});
     args::Flag no_toposort(parser, "no-toposort", "don't apply topological sorting in the sort pipeline", {'T', "no-toposort"});
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 100;
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
     uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
-    uint64_t max_spoa_length = _max_spoa_length ? args::get(_max_spoa_length) : 10000;
+    uint64_t max_poa_length = _max_poa_length ? args::get(_max_poa_length) : 10000;
 
     std::int8_t poa_m = 1;
     std::int8_t poa_n = -4;
@@ -122,11 +122,15 @@ int main(int argc, char** argv) {
                                               min_subpath,
                                               max_edge_jump);
 
+    uint64_t min_autocorr_z = 5;
+    uint64_t autocorr_stride = 50;
     smoothxg::break_blocks(graph,
                            blocks,
+                           max_poa_length,
                            min_copy_length,
                            max_copy_length,
-                           max_spoa_length);
+                           min_autocorr_z,
+                           autocorr_stride);
 
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,8 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0]", {'k', "min-subpath"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 100]", {'e', "max-edge-jump"});
-    args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to attempt to allow to collapse [default: 1000]", {'c', "min-copy-length"});
+    args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to collapse [default: 1000]", {'c', "min-copy-length"});
+    args::ValueFlag<uint64_t> _max_copy_length(parser, "N", "maximum repeat length to attempt to detect [default: 20000]", {'m', "max-copy-length"});
     args::ValueFlag<uint64_t> _max_spoa_length(parser, "N", "maximum sequence length to put into spoa [default: 10000]", {'l', "max-spoa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<int> _poa_m(parser, "N", "spoa score for matching bases [default: 1]", {'M', "poa-match"});
@@ -98,13 +99,14 @@ int main(int argc, char** argv) {
     uint64_t min_subpath = _min_subpath ? args::get(_min_subpath) : 0;
     uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 100;
     uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
+    uint64_t max_copy_length = _max_copy_length ? args::get(_max_copy_length) : 20000;
     uint64_t max_spoa_length = _max_spoa_length ? args::get(_max_spoa_length) : 10000;
 
     std::int8_t poa_m = 1;
     std::int8_t poa_n = -4;
     std::int8_t poa_g = -6;
     std::int8_t poa_e = -1;
-    std::int8_t poa_q = -8;
+    std::int8_t poa_q = -6;
     std::int8_t poa_c = -1;
 
     if (_poa_m) poa_m = args::get(_poa_m);
@@ -120,8 +122,10 @@ int main(int argc, char** argv) {
                                               min_subpath,
                                               max_edge_jump);
 
-    smoothxg::break_blocks(blocks,
+    smoothxg::break_blocks(graph,
+                           blocks,
                            min_copy_length,
+                           max_copy_length,
                            max_spoa_length);
 
     auto smoothed = smoothxg::smooth_and_lace(graph,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "smooth.hpp"
 #include "xg.hpp"
 #include "prep.hpp"
+#include "breaks.hpp"
 #include "odgi/odgi.hpp"
 
 using namespace std;
@@ -33,6 +34,8 @@ int main(int argc, char** argv) {
     args::ValueFlag<uint64_t> _max_block_jump(parser, "N", "maximum path jump to include in block [default: 5000]", {'j', "max-path-jump"});
     args::ValueFlag<uint64_t> _min_subpath(parser, "N", "minimum length of a subpath to include in partial order alignment [default: 0]", {'k', "min-subpath"});
     args::ValueFlag<uint64_t> _max_edge_jump(parser, "N", "maximum edge jump before breaking [default: 100]", {'e', "max-edge-jump"});
+    args::ValueFlag<uint64_t> _min_copy_length(parser, "N", "minimum repeat length to attempt to allow to collapse [default: 1000]", {'c', "min-copy-length"});
+    args::ValueFlag<uint64_t> _max_spoa_length(parser, "N", "maximum sequence length to put into spoa [default: 10000]", {'l', "max-spoa-length"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<int> _poa_m(parser, "N", "spoa score for matching bases [default: 1]", {'M', "poa-match"});
     args::ValueFlag<int> _poa_n(parser, "N", "spoa score for mismatching bases [default: -4]", {'N', "poa-mismatch"});
@@ -94,6 +97,8 @@ int main(int argc, char** argv) {
     uint64_t max_block_jump = _max_block_jump ? args::get(_max_block_jump) : 5000;
     uint64_t min_subpath = _min_subpath ? args::get(_min_subpath) : 0;
     uint64_t max_edge_jump = _max_edge_jump ? args::get(_max_edge_jump) : 100;
+    uint64_t min_copy_length = _min_copy_length ? args::get(_min_copy_length) : 1000;
+    uint64_t max_spoa_length = _max_spoa_length ? args::get(_max_spoa_length) : 10000;
 
     std::int8_t poa_m = 1;
     std::int8_t poa_n = -4;
@@ -114,6 +119,10 @@ int main(int argc, char** argv) {
                                               max_block_jump,
                                               min_subpath,
                                               max_edge_jump);
+
+    smoothxg::break_blocks(blocks,
+                           min_copy_length,
+                           max_spoa_length);
 
     auto smoothed = smoothxg::smooth_and_lace(graph,
                                               blocks,

--- a/src/smooth.cpp
+++ b/src/smooth.cpp
@@ -33,13 +33,38 @@ odgi::graph_t smooth(const xg::XG& graph,
         names.push_back(namess.str());
     }
     /*
-    std::string s = "smoothxg_block_" + std::to_string(block_id) + ".fa";
-    std::ofstream fasta(s.c_str());
-    for (uint64_t i = 0; i < seqs.size(); ++i) {
-        fasta << ">" << names[i] << " " << seqs[i].size() << std::endl
-              << seqs[i] << std::endl;
+    {
+        std::string s = "smoothxg_block_" + std::to_string(block_id) + ".fa";
+        std::ofstream fasta(s.c_str());
+        for (uint64_t i = 0; i < seqs.size(); ++i) {
+            fasta << ">" << names[i] << " " << seqs[i].size() << std::endl
+                  << seqs[i] << std::endl;
+        }
+        fasta.close();
+        const VectorizableHandleGraph& vec_graph = dynamic_cast<const VectorizableHandleGraph&>(graph);
+        std::string v = "smoothxg_block_" + std::to_string(block_id) + ".tsv";
+        std::ofstream vs(v.c_str());
+        vs << "path.name\tstep.rank\tpos\tnode.id\tnode.pos\tvisit" << std::endl;
+        for (auto& path_range : block.path_ranges) {
+            std::string path_name = graph.get_path_name(graph.get_path_handle_of_step(path_range.begin));
+            uint64_t rank = 0;
+            uint64_t pos = 0;
+            std::map<uint64_t, uint64_t> visits;
+            for (step_handle_t step = path_range.begin;
+                 step != path_range.end;
+                 step = graph.get_next_step(step)) {
+                handle_t h = graph.get_handle_of_step(step);
+                uint64_t id = graph.get_id(h);
+                int64_t node_pos = vec_graph.node_vector_offset(id);
+                auto& visit = visits[id];
+                vs << path_name << "\t" << rank++ << "\t" << pos << "\t"
+                   << id << "\t" << node_pos << "\t" << visit << std::endl;
+                ++visit;
+                pos += graph.get_length(graph.get_handle_of_step(step));
+            }
+        }
+        vs.close();
     }
-    fasta.close();
     */
     // set up POA
     // done...


### PR DESCRIPTION
With this commit, we cut blocks where we would have more than a maximum amount of sequence from any given input.

The cutting is guided by inference of VNTRs when they are present, and if a VNTR is found, the cut length is set to 1/2 the mean length of the repeat we find (considering repeats found in all sequences).

This ensures that we don't accidentally end up with too much sequence in spoa, which can easily exhaust memory.